### PR TITLE
fix relative link

### DIFF
--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -29,7 +29,7 @@
 
   <nav>
     {{#each content.sections}}
-      <section id="{{id}}" {{#equal id ../page.section}}class="active"{{/equal}}>
+      <section {{#equal id ../page.section}}class="active"{{/equal}}>
 
         <h2 title="{{title}}">
           <a href="#">{{title}}</a>


### PR DESCRIPTION
@linclark @cowperthwait
 
Currently, if clicking "files" on https://docs.npmjs.com/files/package.json, and https://docs.npmjs.com/files/package.json#files doesn't take you where you'd expect.

This is caused by one of the sections with a clashing id. 
Just removed the id from the section as its unused. 
Could be put back as another attribute if that's wanted